### PR TITLE
Fix environment variables

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,9 @@
+//In this file must be the environment variables of Nativo NFT together with the corresponding values for its operation
+//In order to run the project locally it is necessary to create the .env.local file with the file variables shown here
+REACT_APP_CONTRACT=
+REACT_APP_NEAR_ENV=
+REACT_APP_API_TG=
+REACT_APP_MINTER_CONTRACT=
+REACT_APP_FEE_CREATE_COL=
+REACT_APP_FEE_CREATE_NFT=
+REACT_APP_FEE_OFFERS=

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 yarn.lock
 build
-
+.env.local
 
 src/tailwind.output.css

--- a/frontend/amplify.yml
+++ b/frontend/amplify.yml
@@ -11,6 +11,11 @@ applications:
           commands:
             - REACT_APP_CONTRACT=${REACT_APP_CONTRACT}
             - REACT_APP_NEAR_ENV=${REACT_APP_NEAR_ENV}
+            - REACT_APP_API_TG=${REACT_APP_API_TG}
+            - REACT_APP_MINTER_CONTRACT=${REACT_APP_MINTER_CONTRACT}
+            - REACT_APP_FEE_CREATE_COL=${REACT_APP_FEE_CREATE_COL}
+            - REACT_APP_FEE_CREATE_NFT=${REACT_APP_FEE_CREATE_NFT}
+            - REACT_APP_FEE_OFFERS=${REACT_APP_FEE_OFFERS}
             - npm run build-prod-tailwind
             - npm run build
       artifacts:

--- a/frontend/src/components/modalRevender.component.js
+++ b/frontend/src/components/modalRevender.component.js
@@ -72,7 +72,7 @@ export default function ModalRevender(props) {
         revender = await contract.market_sell_generic(
           payload,
           300000000000000, // attached GAS (optional)
-          amount
+          0
         );
         /*  revender.status = revender.on_sale; */
       }

--- a/frontend/src/utils/near_interaction.js
+++ b/frontend/src/utils/near_interaction.js
@@ -9,7 +9,7 @@ import {
 export const storage_byte_cost = 10000000000000000000;
 //export const contract_name = "nativo.near";
 //export const contract_name = "dokxo.testnet";
-export const contract_name =(process.env.REACT_APP_CONTRACT === undefined ? "dev-1646324960363-24989034737776" : process.env.REACT_APP_CONTRACT);
+export const contract_name =process.env.REACT_APP_CONTRACT;
 export const config = {
   testnet: {
     networkId: "testnet",

--- a/frontend/src/views/Detail.view.js
+++ b/frontend/src/views/Detail.view.js
@@ -39,7 +39,7 @@ function LightEcommerceB(props) {
   const { data } = useParams();
   //es el historial de busqueda
   //let history = useHistory();
-  const APIURL='https://api.thegraph.com/subgraphs/name/luisdaniel2166/nativojson'
+  const APIURL= process.env.REACT_APP_API_TG
 
   React.useEffect(() => {
     (async () => {

--- a/frontend/src/views/MisTokens.view.js
+++ b/frontend/src/views/MisTokens.view.js
@@ -60,7 +60,7 @@ function MisTokens(props) {
   // const [imgs, setImgs] = useState([]);
   let imgs = [];
 
-  const APIURL = 'https://api.thegraph.com/subgraphs/name/luisdaniel2166/nativojson'
+  const APIURL = process.env.REACT_APP_API_TG
 
   const handleChangePage = (e, value) => {
     console.log(value)
@@ -452,7 +452,7 @@ function MisTokens(props) {
       quitar = await contract.market_remove_generic(
         payload,
         300000000000000, // attached GAS (optional)
-        amount
+        0
       );
       Swal.fire({
         title: 'NFT quitado de la venta',

--- a/frontend/src/views/collectionGallery.js
+++ b/frontend/src/views/collectionGallery.js
@@ -51,7 +51,7 @@ function LightEcommerceA() {
     price: "null",
   });
 
-  const APIURL = 'https://api.thegraph.com/subgraphs/name/luisdaniel2166/nativojson'
+  const APIURL = process.env.REACT_APP_API_TG
 
   const handleChangePage = (e, value) => {
     // console.log(value)

--- a/frontend/src/views/createColl.js
+++ b/frontend/src/views/createColl.js
@@ -64,7 +64,7 @@ function LightHeroE(props) {
 
   const [actualDate, setactualDate] = useState("");
   let collectionData
-  const APIURL = 'https://api.thegraph.com/subgraphs/name/luisdaniel2166/nativojson'
+  const APIURL = process.env.REACT_APP_API_TG
 
   //guardara todos los valores del formulario
   const pru = (parseInt(Math.random() * 100000) + 1);
@@ -214,7 +214,7 @@ function LightHeroE(props) {
     let contract = await getNearContract();
     const owner = await getNearAccount()
     let payloadCol = {
-      address_contract: "nativo-minter.testnet",
+      address_contract: process.env.REACT_APP_MINTER_CONTRACT,
       address_collection_owner: owner,
       title: title,
       descrip: desc,
@@ -248,7 +248,7 @@ function LightHeroE(props) {
       })
       return
     }
-    let amount = fromNearToYocto(0.05);
+    let amount = fromNearToYocto(process.env.REACT_APP_FEE_CREATE_COL);
     let colResult = await contract.add_user_collection(
       payloadCol,
       300000000000000,

--- a/frontend/src/views/mintNft.view.js
+++ b/frontend/src/views/mintNft.view.js
@@ -52,7 +52,7 @@ function LightHeroE(props) {
 
   const [actualDate, setactualDate] = useState("");
   let collectionData
-  const APIURL = 'https://api.thegraph.com/subgraphs/name/luisdaniel2166/nativojson'
+  const APIURL = process.env.REACT_APP_API_TG
   useEffect(() => {
     const valores = window.location.search;
     const values = new URLSearchParams(valores)
@@ -213,7 +213,7 @@ function LightHeroE(props) {
         const owner = await getNearAccount()
         console.log(fromNearToYocto(values.price))
         let newPayload = {
-          address_contract: "nativo-minter.testnet",//(comboCol? values.contractCol : contData),
+          address_contract: process.env.REACT_APP_MINTER_CONTRACT,//(comboCol? values.contractCol : contData),
           token_owner_id: owner,
           collection_id: colID,
           collection: collTitle,
@@ -238,7 +238,7 @@ function LightHeroE(props) {
         //     //extra: "{'culture':'Azteca','country':'Mexico','creator':'joehank.testnet','price':'10','on_sale':true,'on_auction':false,'adressbidder':'accountbidder','highestbidder':'notienealtos','lowestbidder':'notienebajos','expires_at':'noexpira','starts_at':'noinicia'}"
         //   },
         // };
-        let amount = fromNearToYocto(0.05);
+        let amount = fromNearToYocto(process.env.REACT_APP_FEE_CREATE_NFT);
         console.log(newPayload)
         if(collTitle == ""){
           Swal.fire({

--- a/frontend/src/views/tokensCollection.js
+++ b/frontend/src/views/tokensCollection.js
@@ -51,7 +51,7 @@ function LightEcommerceA() {
     price: "null",
   });
 
-  const APIURL = 'https://api.thegraph.com/subgraphs/name/luisdaniel2166/nativojson'
+  const APIURL = process.env.REACT_APP_API_TG
 
   const handleChangePage = (e, value) => {
     //console.log(value)


### PR DESCRIPTION
The necessary environment variables were added to be able to use nativo NFT without hardcoding data into the code, the following environment variables were generated:

- REACT_APP_CONTRACT = native-market.testnet
- REACT_APP_NEAR_ENV = testnet
- REACT_APP_API_TG = https://api.thegraph.com/subgraphs/name/luisdaniel2166/nativojson
- REACT_APP_MINTER_CONTRACT = native-minter.testnet
- REACT_APP_FEE_CREATE_COL = 0.05
- REACT_APP_FEE_CREATE_NFT = 0.05
- REACT_APP_FEE_OFFERS = 0.05

Some of the variables were already registered in amplify but some need to be registered, it must be taken into account that depending on the network and where they are being used, they will change their value either for deployment on mainnet or on testnet.

Fees for putting up for sale and removing from sale were also changed so as not to charge for these actions